### PR TITLE
Allow encrypted files

### DIFF
--- a/media.py
+++ b/media.py
@@ -6,7 +6,7 @@ from maubot.handlers import command
 
 
 class MediaBot(Plugin):
-    @command.passive("^mxc://.+/.+$", field=lambda evt: evt.content.url,
+    @command.passive("^mxc://.+/.+$", field=lambda evt: evt.content.url if evt.content.url else evt.content.file.url,
                      msgtypes=(MessageType.IMAGE, MessageType.FILE, MessageType.AUDIO,
                                MessageType.STICKER))
     async def handler(self, evt: MessageEvent, url: Tuple[str]) -> None:


### PR DESCRIPTION
Fix the error
```
maubot_1                     | Traceback (most recent call last):
maubot_1                     |   File "/usr/lib/python3.8/site-packages/mautrix/client/syncer.py", line 200, in _catch_errors
maubot_1                     |     await handler(data)
maubot_1                     |   File "/opt/maubot/maubot/handlers/command.py", line 378, in replacement
maubot_1                     |     match = regex.search(data)
maubot_1                     | TypeError: expected string or bytes-like object
```
if files are encrypted